### PR TITLE
feat: nginx, flask/uwsgi를 컨테이너화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+services:
+    flask_1:
+        build: ./flask
+        container_name: flask1
+        expose:
+            - 5000
+    proxy:
+        build: ./nginx
+        container_name: nginx
+        ports:
+            - "80:80"
+        restart: "unless-stopped"

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+RUN mkdir /marvel_tmi
+WORKDIR /marvel_tmi
+COPY ./requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt
+COPY . . 
+CMD ["uwsgi", "uwsgi.ini"]

--- a/flask/uwsgi.ini
+++ b/flask/uwsgi.ini
@@ -1,6 +1,7 @@
 [uwsgi]
 module=run
-socket=myproject.sock
-chmod-socket=666
+socket= :5000
+master = true
+chmod-socket=660
 vacuum=true
 die-on-term=true

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,10 @@
-FROM nginx
-RUN rm /etc/nginx/conf.d/default.conf
-COPY nginx.conf /etc/nginx/conf.d/
+FROM ubuntu:20.04
+RUN apt-get update
+RUN apt-get install nginx -y
+RUN rm /etc/nginx/conf.d/default.conf -f
+RUN rm /etc/nginx/nginx.conf -f
+ADD ./nginx.conf /etc/nginx/
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,6 @@
-events{}
+events{
+	worker_connections 4000;
+}
 
 http{
 	server{
@@ -6,7 +8,7 @@ http{
 		server_name 0.0.0.0;
 		location / {
 			include uwsgi_params;
-			uwsgi_pass unix:/home/yosef/Documents/marvel_tmi/marvel_tmi/myproject.sock;
+			 uwsgi_pass flask_1:5000;
 		}
 	}
 }


### PR DESCRIPTION
- Docker 컨테이너를 이용하여 flask와 nginx를 컨테이너화.
- nginx가 유저의 요청을 받으면 해당 요청을 uwsgi의 소켓으로 전달하고 uwsgi는 flask에 전달.
- 추후 flask 인스턴스의 개수를 늘려 nginx를 통해 로드 밸런싱할 예정.